### PR TITLE
Removed what seems to be left over from the free-wili docs

### DIFF
--- a/docs/introduction-and-overview.md
+++ b/docs/introduction-and-overview.md
@@ -58,7 +58,6 @@ With a Raspberry Pi Pico, the uses are infinite! However, this isn't just a Rasp
 
 - 1x 10BASE-T1L Interface based on [Analog Devices ADIN1110](https://www.analog.com/en/resources/technical-articles/enabling-seamless-ethernet-to-field-with-10base-t1l-connectivity.html) 
 - 1x CAN FD Interface: Based on [Microchip MCP2518FD](https://www.microchip.com/en-us/product/MCP2518FD) binary compatible with [CANIS lab CANPICO](https://canislabs.com/canpico/)
-- Black contains two Texas Instruments CC1101 Sub Ghz Radios with programmable filter ranges for 300-348, 387-464, 779-928 bands.
 - RS485 Modbus Interface
 - 6x Serial RGB Color Programmable LED
 - 4-20mA Sensor Simulator


### PR DESCRIPTION
In the whale tail badge docs ( https://whaletail.freewili.com/introduction-and-overview/ ) it states 

> Black contains two Texas Instruments CC1101 Sub Ghz Radios with programmable filter ranges for 300-348, 387-464, 779-928 bands.

under the summary of key features which is similar to the wording on the free wili which will have different versions the current one being black like stated on the whale tail docs. i'm guessing this was left over while using the free-wili docs as a template? ( as a similiar line is at the bottom of this page https://docs.freewili.com/ )

as in the further docs no mention of the radios are there and from staring at the badge several times i don't see any texas instrument cc1101 chips on it. so im guessing its just a error? this pr just deletes that line of what i think is incorrect. if i'm wrong sorry for wasting time but figured id mention it.